### PR TITLE
Revert "Add Cadence as supported programming language"

### DIFF
--- a/src/media/example_prompt_config.json
+++ b/src/media/example_prompt_config.json
@@ -109,8 +109,7 @@
       "sql": [],
       "latex": [],
       "objective-cpp": [],
-      "shaderlab": [],
-      "cadence": []
+      "shaderlab": []
     }
   }
 }

--- a/src/media/supportedProgrammingLanguages.ts
+++ b/src/media/supportedProgrammingLanguages.ts
@@ -60,5 +60,4 @@ export const supportedLanguages = [
   "latex",
   "objective-cpp",
   "shaderlab",
-  "cadence",
 ];


### PR DESCRIPTION
Thank you for your help. Yet the program doesn't use `src/media/example_prompt_config.json` anymore. In the future, similar requests should contribute to [supportedProgrammingLanguages.ts](../tree/main/src/media/supportedProgrammingLanguages.ts).